### PR TITLE
Add dockerfile linter in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,33 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  dockerfile-linter:
+    runs-on: ubuntu-latest
+    env:
+      HADOLINT_RECURSIVE: "true"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile.neuron
+          recursive: true
+          failure-threshold: error # TODO: enable more linter rules other than error.
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile.neuronx
+          recursive: true
+          failure-threshold: error


### PR DESCRIPTION
Add dockerfile linter in CI

Had to add two steps for neuron and neuronx.
Hadolint-action supports multiple Dockerfiles by pattern but seems not arbitrary two names.
Using pattern "Dockerfile.*" will include cve allowlists and they cannot be excluded.

Only fail on error for now. Can refactor to remove warning and info later.