### PR TITLE
Add brief introduction and release steps 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
-## Neuron Deep Learning Containers
+## AWS Neuron Deep Learning Containers
 
-TODO: Fill this README out!
-
-Be sure to:
-
-* Change the title in this README
-* Edit your repository description on GitHub
+AWS Neuron Deep Learning Containers (DLCs) are a set of Docker images for training and serving models on AWS Trainium and Inferentia instances using AWS Neuron SDK.
 
 ## Security
 
@@ -14,4 +9,3 @@ See [SECURITY](SECURITY.md) for more information.
 ## License
 
 This project is licensed under the Apache-2.0 License.
-

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+## Creating a release
+
+Follow the Github official [documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) to create release.
+
+* Step 4:
+    * Create a new tag for each release.
+    * The version number should be same as the one of packaged [AWS Neuron](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/release-notes/index.html).
+* Step 5:
+    * The target should always be "main" branch.
+* Step 6:
+    * Choose "auto".
+* Step 7:
+    * Title is same as version number.
+* Step 8:
+    * Automatically generate release notes.
+* Steps 9 - 12 can be skipped for now:
+    * No need to attach binaries. The Neuron DLC images are released in ECR. The releases of this repo are only pointing Dockerfiles.


### PR DESCRIPTION
*Description of changes:*

Add brief introduction and release steps to README

We can also put the release runbook in https://github.com/aws-neuron/deep-learning-containers/blob/main/CONTRIBUTING.md, or have a separated MAINTAINER_GUIDE.md. Let me know if you prefer other locations.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
