### PR TITLE
Install neuron-cc[tensorflow] in Pytorch 1.13.1 Inf1 Image

### DIFF
--- a/docker/pytorch/inference/1.13.1/Dockerfile.neuron
+++ b/docker/pytorch/inference/1.13.1/Dockerfile.neuron
@@ -107,7 +107,7 @@ RUN pip install --no-cache-dir -U \
     boto3 \
     cryptography
 
-RUN pip install neuron-cc==$NEURON_CC_VERSION --extra-index-url https://pip.repos.neuron.amazonaws.com \
+RUN pip install "neuron-cc[tensorflow]==$NEURON_CC_VERSION" --extra-index-url https://pip.repos.neuron.amazonaws.com \
     torch-neuron==$NEURON_FRAMEWORK_VERSION \
  && pip install -U protobuf==3.19.5 \
     torchserve==${TORCHSERVE_VERSION} \


### PR DESCRIPTION
The tensorflow extra package is required to torch.neuron.trace a Pytorch model. This change matches the Ubuntu 20.04 install instructions in the AWS Neuron setup docs.

*Issue #, if available:* None

*Description of changes:* Add the extra tensorflow packages when installing neuron-cc. Matches the ubuntu 20.04 install instructions here: https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/setup/neuron-setup/pytorch/neuron/ubuntu/torch-neuron-ubuntu20.html#setup-torch-neuron-u20


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
