### PR TITLE
Quote `opencv-python` version pin

### DIFF
--- a/docker/pytorch/inference/2.6.0/Dockerfile.neuronx
+++ b/docker/pytorch/inference/2.6.0/Dockerfile.neuronx
@@ -87,7 +87,7 @@ RUN /opt/conda/bin/mamba install -c conda-forge \
  && rm -rf ~/.cache/pip/*
 
 RUN ${PIP} install --no-cache-dir -U \
-    opencv-python>=4.8.1.78 \
+    "opencv-python>=4.8.1.78" \
     "numpy<1.24,>1.21" \
     "scipy>=1.8.0" \
     six \


### PR DESCRIPTION
*Issue #, if available:* 
Without quotes, `opencv-python` will remain unpinned. `>` is interpreted as output redirection. 

*Description of changes:*
Add quote to version pin

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
