### PR TITLE
Remove double https prefix from Dockerfiles

### DIFF
--- a/docker/jax/training/0.5/Dockerfile.neuronx
+++ b/docker/jax/training/0.5/Dockerfile.neuronx
@@ -148,9 +148,9 @@ RUN HOME_DIR=/root \
  && rm -rf /tmp/tmp*
 
 # Setting up APT and PIP repo for neuron artifacts
-ARG NEURON_APT_REPO=https://apt.repos.neuron.amazonaws.com
+ARG NEURON_APT_REPO=apt.repos.neuron.amazonaws.com
 ARG NEURON_APT_REPO_KEY
-ARG NEURON_PIP_REPO=https://pip.repos.neuron.amazonaws.com
+ARG NEURON_PIP_REPO=pip.repos.neuron.amazonaws.com
 ARG NEURON_PIP_REPO_KEY
 RUN mkdir -p /etc/apt/keyrings \
  && APT_REPO_PREFIX=$([ -n "${NEURON_APT_REPO_KEY}" ] && echo "${NEURON_APT_REPO_KEY}@" || echo "") \

--- a/docker/jax/training/0.6/Dockerfile.neuronx
+++ b/docker/jax/training/0.6/Dockerfile.neuronx
@@ -148,9 +148,9 @@ RUN HOME_DIR=/root \
  && rm -rf /tmp/tmp*
 
 # Setting up APT and PIP repo for neuron artifacts
-ARG NEURON_APT_REPO=https://apt.repos.neuron.amazonaws.com
+ARG NEURON_APT_REPO=apt.repos.neuron.amazonaws.com
 ARG NEURON_APT_REPO_KEY
-ARG NEURON_PIP_REPO=https://pip.repos.neuron.amazonaws.com
+ARG NEURON_PIP_REPO=pip.repos.neuron.amazonaws.com
 ARG NEURON_PIP_REPO_KEY
 RUN mkdir -p /etc/apt/keyrings \
  && APT_REPO_PREFIX=$([ -n "${NEURON_APT_REPO_KEY}" ] && echo "${NEURON_APT_REPO_KEY}@" || echo "") \

--- a/docker/pytorch/inference/2.6.0/Dockerfile.neuronx
+++ b/docker/pytorch/inference/2.6.0/Dockerfile.neuronx
@@ -132,9 +132,9 @@ RUN HOME_DIR=/root \
 RUN curl -o /license.txt  https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.5/license.txt
 
 # Setting up APT and PIP repo for neuron artifacts
-ARG NEURON_APT_REPO=https://apt.repos.neuron.amazonaws.com
+ARG NEURON_APT_REPO=apt.repos.neuron.amazonaws.com
 ARG NEURON_APT_REPO_KEY
-ARG NEURON_PIP_REPO=https://pip.repos.neuron.amazonaws.com
+ARG NEURON_PIP_REPO=pip.repos.neuron.amazonaws.com
 ARG NEURON_PIP_REPO_KEY
 RUN mkdir -p /etc/apt/keyrings \
  && APT_REPO_PREFIX=$([ -n "${NEURON_APT_REPO_KEY}" ] && echo "${NEURON_APT_REPO_KEY}@" || echo "") \

--- a/docker/pytorch/inference/2.7.0/Dockerfile.neuronx
+++ b/docker/pytorch/inference/2.7.0/Dockerfile.neuronx
@@ -133,9 +133,9 @@ RUN HOME_DIR=/root \
 RUN curl -o /license.txt  https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.7/license.txt
 
 # Setting up APT and PIP repo for neuron artifacts
-ARG NEURON_APT_REPO=https://apt.repos.neuron.amazonaws.com
+ARG NEURON_APT_REPO=apt.repos.neuron.amazonaws.com
 ARG NEURON_APT_REPO_KEY
-ARG NEURON_PIP_REPO=https://pip.repos.neuron.amazonaws.com
+ARG NEURON_PIP_REPO=pip.repos.neuron.amazonaws.com
 ARG NEURON_PIP_REPO_KEY
 RUN mkdir -p /etc/apt/keyrings \
  && APT_REPO_PREFIX=$([ -n "${NEURON_APT_REPO_KEY}" ] && echo "${NEURON_APT_REPO_KEY}@" || echo "") \

--- a/docker/vllm/inference/0.7.2/Dockerfile.neuronx
+++ b/docker/vllm/inference/0.7.2/Dockerfile.neuronx
@@ -137,9 +137,9 @@ RUN HOME_DIR=/root \
  && rm -rf ${HOME_DIR}/.cache/conda
 
 # Setting up APT and PIP repo for neuron artifacts
-ARG NEURON_APT_REPO=https://apt.repos.neuron.amazonaws.com
+ARG NEURON_APT_REPO=apt.repos.neuron.amazonaws.com
 ARG NEURON_APT_REPO_KEY
-ARG NEURON_PIP_REPO=https://pip.repos.neuron.amazonaws.com
+ARG NEURON_PIP_REPO=pip.repos.neuron.amazonaws.com
 ARG NEURON_PIP_REPO_KEY
 RUN mkdir -p /etc/apt/keyrings \
  && APT_REPO_PREFIX=$([ -n "${NEURON_APT_REPO_KEY}" ] && echo "${NEURON_APT_REPO_KEY}@" || echo "") \

--- a/docker/vllm/inference/0.9.1/Dockerfile.neuronx
+++ b/docker/vllm/inference/0.9.1/Dockerfile.neuronx
@@ -137,9 +137,9 @@ RUN HOME_DIR=/root \
  && rm -rf ${HOME_DIR}/.cache/conda
 
 # Setting up APT and PIP repo for neuron artifacts
-ARG NEURON_APT_REPO=https://apt.repos.neuron.amazonaws.com
+ARG NEURON_APT_REPO=apt.repos.neuron.amazonaws.com
 ARG NEURON_APT_REPO_KEY
-ARG NEURON_PIP_REPO=https://pip.repos.neuron.amazonaws.com
+ARG NEURON_PIP_REPO=pip.repos.neuron.amazonaws.com
 ARG NEURON_PIP_REPO_KEY
 RUN mkdir -p /etc/apt/keyrings \
  && APT_REPO_PREFIX=$([ -n "${NEURON_APT_REPO_KEY}" ] && echo "${NEURON_APT_REPO_KEY}@" || echo "") \


### PR DESCRIPTION
*Description of changes:*
Removing the https prefix from the APT and PIP repos. Shell command already had that, so double quoting resulted in error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
