### PR TITLE
feat: add github actions for vLLM docker image build

### DIFF
--- a/.github/workflows/build-neuron-vllm-inference-dlc.yaml
+++ b/.github/workflows/build-neuron-vllm-inference-dlc.yaml
@@ -1,0 +1,95 @@
+name: Build Neuron vLLM Inference DLC
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'docker/vllm/inference/**'
+      - 'docker/common/**'
+      - '.github/workflows/build-neuron-vllm-inference-dlc.yaml'
+  pull_request:
+    branches: [ main ]        
+    paths:
+      - 'docker/vllm/inference/**'
+      - 'docker/common/**'
+  workflow_dispatch:    
+    inputs:
+        vllm_versions:
+          description: 'vLLM versions to build (comma-separated, e.g., "0.9.1,0.7.2")'
+          required: false
+          default: '0.9.1'
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.changes.outputs.matrix }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed versions
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Use manual input versions
+            versions="${{ github.event.inputs.vllm_versions }}"
+            matrix_json="[]"
+            IFS=',' read -ra VERSION_ARRAY <<< "$versions"
+            for version in "${VERSION_ARRAY[@]}"; do
+              version=$(echo "$version" | xargs) # trim whitespace
+              path="docker/vllm/inference/$version"
+              if [ -f "$path/Dockerfile.neuronx" ]; then
+                matrix_json=$(echo "$matrix_json" | jq ". + [{\"version\": \"$version\", \"path\": \"$path\"}]")
+              fi
+            done
+          else
+            # Detect changed Dockerfile paths
+            changed_paths=$(git diff --name-only origin/${{ github.base_ref }} ${{ github.sha }} \
+              | grep '^docker/vllm/inference/.*/Dockerfile.neuronx$' \
+              | xargs -n1 dirname \
+              | sort -u)
+            
+            matrix_json="[]"
+            for path in $changed_paths; do
+              version=$(basename "$path")
+              matrix_json=$(echo "$matrix_json" | jq ". + [{\"version\": \"$version\", \"path\": \"$path\"}]")
+            done
+          fi
+
+          matrix_compact=$(echo "$matrix_json" | jq -c .)
+          echo "Matrix JSON: $matrix_compact"
+          echo "matrix=$matrix_compact" >> $GITHUB_OUTPUT
+
+  build:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.matrix != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
+
+    steps:
+      - name: Delete unnecessary tools folder to free runner space
+        run: rm -rf /opt/hostedtoolcache
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Copy common files next to Dockerfile
+        run: |
+          cp -r docker/common/* ${{ matrix.path }}/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.path }}
+          file: ${{ matrix.path }}/Dockerfile.neuronx
+          platforms: linux/amd64
+          tags: neuron-vllm-inference-dlc:${{ matrix.version }}-${{ github.sha }}
+          push: false


### PR DESCRIPTION
*Description of changes:*
GH actions with workflow dispatch and manual run. Works only for vLLM image now. No ECR push yet.

Successful build in my fork - https://github.com/ahsan-z-khan/neuron-deep-learning-containers/actions/runs/16890704990

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
