### PR TITLE
fix: Update vLLM Dockerfile to remove the vLLM package removal

### DIFF
--- a/docker/vllm/inference/0.9.1/Dockerfile.neuronx
+++ b/docker/vllm/inference/0.9.1/Dockerfile.neuronx
@@ -223,9 +223,7 @@ RUN cd /tmp \
  && git clone -b 2.25.0 https://github.com/aws-neuron/upstreaming-to-vllm.git \
  && cd upstreaming-to-vllm \
  && ${PIP} install --no-cache-dir -r requirements/neuron.txt \
- && VLLM_TARGET_DEVICE="neuron" ${PIP} install --no-cache-dir -e . \
- && cd / \
- && rm -rf /tmp/upstreaming-to-vllm
+ && VLLM_TARGET_DEVICE="neuron" ${PIP} install --no-cache-dir -e .
 
 WORKDIR ${APP_MOUNT}/vllm
 


### PR DESCRIPTION
*Description of changes:*
vLLM 0.9.1 Dockerfile has bug where it's removing the editable vLLM installation. removing those lines from Dockerfile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
